### PR TITLE
Formant drop amp coef

### DIFF
--- a/polyglotdb/acoustics/formants/helper.py
+++ b/polyglotdb/acoustics/formants/helper.py
@@ -78,8 +78,10 @@ def parse_multiple_formant_output(output):
     to_return = {}
     for item in listing_list:
         output = parse_point_script_output(item)
-
-        to_return[track_nformants(output)] = output
+        # print (output)
+        reported_nformants = output.pop('num_formants')
+        # to_return[track_nformants(output)] = output
+        to_return[reported_nformants] = output
     return to_return
 
 
@@ -106,6 +108,7 @@ def generate_variable_formants_point_function(corpus_context, min_formants, max_
     script = os.path.join(script_dir, 'multiple_num_formants.praat')
     formant_function = PraatAnalysisFunction(script, praat_path=corpus_context.config.praat_path,
                                              arguments=[0.01, 0.025, min_formants, max_formants, max_freq])
+
     formant_function._function._output_parse_function = parse_multiple_formant_output
     return formant_function
 
@@ -208,7 +211,7 @@ def get_mahalanobis(prototype, observation, inverse_covariance):
 
 
 def save_formant_point_data(corpus_context, data, num_formants=False):
-    header = ['id', 'F1', 'F2', 'F3', 'B1', 'B2', 'B3']
+    header = ['id', 'F1', 'F2', 'F3', 'B1', 'B2', 'B3', 'A1', 'A2', 'A3', 'Ax', 'drop_formant']
     if num_formants:
         header += ['num_formants']
     point_measures_to_csv(corpus_context, data, header)
@@ -216,8 +219,10 @@ def save_formant_point_data(corpus_context, data, num_formants=False):
     for h in header:
         if h == 'id':
             continue
-        if h != 'num_formants':
+        if h != 'num_formants' or h !='drop_formant':
             header_info[h] = float
+        # elif h != 'Fx':
+        #     header_info[h] = str
         else:
             header_info[h] = int
     point_measures_from_csv(corpus_context, header_info)

--- a/polyglotdb/acoustics/formants/multiple_num_formants.praat
+++ b/polyglotdb/acoustics/formants/multiple_num_formants.praat
@@ -6,8 +6,8 @@ form Variables
 	real padding
 	real timestep
 	real windowlen
-    integer minformants
-	integer maxformants
+    positive minformants
+	positive maxformants
 	integer ceiling
 endform
 
@@ -40,38 +40,95 @@ r$ = fixed$(r, 3)
 
 final_output$ = ""
 
-for nformants from minformants to maxformants
+# SELECT A SMALL CLIP AND MAKE AN LTAS FOR MEASURING FORMANT AMPLITUDE
+max_fb_for_a = 300
+selectObject: "Sound segment_of_interest"
+sound_samplerate = Get sampling frequency
+#ltas_bandwidth = ceiling(sound_samplerate/2048)
+ltas_bandwidth = ceiling(sound_samplerate/512)
+ltas_window_start = max(begin,r-0.0125)
+ltas_window_end = min(r+0.0125,end)
+Extract part: ltas_window_start, ltas_window_end, "rectangular", 1, "yes"
+Rename: "amplitude_window"
+To Ltas: ltas_bandwidth
+
+
+
+#for nformants from minformants to maxformants
+for ncoefficients from minformants*2 to maxformants*2
+    halfcoefficients = ncoefficients / 2
+    nformants = floor(halfcoefficients)
+
     selectObject: "Sound segment_of_interest"
-    To Formant (burg)... 'timestep' 'nformants' 'ceiling' 'windowlen' 50
+    To Formant (burg)... 'timestep' 'halfcoefficients' 'ceiling' 'windowlen' 50
 
 
     output$ = ""
+    output$ = output$ + "num_formants" + tab$
 
     for i from 1 to nformants
     	formNum$ = string$(i)
-    	output$ = output$ + "F" + formNum$ + tab$ + "B" + formNum$
+    	output$ = output$ + "F" + formNum$ + tab$ + "B" + formNum$ + tab$ + "A" + formNum$
         if i <> nformants
             output$ = output$ + tab$
         endif
     endfor
     output$ = output$ + newline$
 
-
-    output$ = output$
+    output$ = output$ + "'halfcoefficients'" + tab$
 
     for j from 1 to nformants
+        selectObject: "Formant segment_of_interest"
         formant = Get value at time... 'j' 'r' Hertz Linear
         formant$ = fixed$(formant, 2)
 
         bw = Get bandwidth at time... 'j' 'r' Hertz Linear
+        bw$ = fixed$(log10(bw), 4)
 
-        ##### JM #####
-        bw = log10(bw)
-        # bw$ = fixed$(bw, 2)
-        bw$ = fixed$(bw, 4)
-        ##############
+        if formant == undefined
+            amp$ = "'undefined'"      
+        else
+            # LIMIT THE DISTANCE AWAY FROM THE CENTER TO LOOK FOR A MAXIMUM (EVEN IF THE BANDWIDTH IS LARGE)
+            halfwindow_up_for_a = min(bw, max_fb_for_a)/2
+            halfwindow_down_for_a = halfwindow_up_for_a
 
-        output$ = output$ + formant$ + tab$ + bw$
+            # DON'T GO MORE THAN HALFWAY TOWARD THE CENTER OF ANOTHER FORMANT
+            if j < nformants
+                formant_up = Get value at time... j+1 r Hertz Linear
+                if formant_up != undefined
+                    halfwindow_up_for_a = min(halfwindow_up_for_a, (formant_up-formant)/2)
+                endif
+            else
+                formant_up = formant + 500
+            endif
+
+            if formant_up != undefined
+                formant_up = formant + 500
+            endif
+
+            if j == 1
+                #TRY TO AVOID F0
+                formant_down = max(formant/2, 200)
+            else
+                formant_down = Get value at time... j-1 r Hertz Linear
+            endif
+            if formant_down != undefined
+                halfwindow_down_for_a = min(halfwindow_down_for_a, (formant-formant_down)/2)
+            endif
+
+            arange_low = formant - halfwindow_down_for_a
+            arange_high = formant + halfwindow_up_for_a
+
+            selectObject: "Ltas amplitude_window"
+            amp = Get maximum: arange_low, arange_high, "None"
+
+            amp$ = fixed$(amp, 4)
+
+        endif
+
+        #fileappend /phon/MontrealCorpusTools/spadedebug.txt time 'r' 'halfcoefficients' F'j' 'arange_low:0'-'arange_high:0' 'formant$' 'bw$' 'amp$''newline$'
+
+        output$ = output$ + formant$ + tab$ + bw$ + tab$ + amp$
 
         if i <> nformants
             output$ = output$ + tab$

--- a/polyglotdb/acoustics/formants/refined.py
+++ b/polyglotdb/acoustics/formants/refined.py
@@ -40,7 +40,9 @@ def read_prototypes(vowel_prototypes_path):
 def analyze_formant_points_refinement(corpus_context, vowel_label='vowel', duration_threshold=0, num_iterations=1,
                                       call_back=None,
                                       stop_check=None,
-                                      vowel_prototypes_path='', multiprocessing=True
+                                      vowel_prototypes_path='', 
+                                      drop_formant=False,
+                                      multiprocessing=True
                                       ):
     """Extracts F1, F2, F3 and B1, B2, B3.
 
@@ -69,10 +71,16 @@ def analyze_formant_points_refinement(corpus_context, vowel_label='vowel', durat
     segment_mapping = generate_vowel_segments(corpus_context, duration_threshold=duration_threshold, padding=0.1, vowel_label=vowel_label)
     best_data = {}
     columns = ['F1', 'F2', 'F3', 'B1', 'B2', 'B3']
+    extra_columns = ['A1', 'A2', 'A3', 'Ax']
+    log_output = []
+    log_output.append(','.join(['speaker','vowel','n','iterations']))
     # Measure with varying levels of formants
     min_formants = 4  # Off by one error, due to how Praat measures it from F0
     # This really measures with 3 formants: F1, F2, F3. And so on.
-    max_formants = 7
+    if drop_formant:
+        max_formants = 8
+    else:
+        max_formants = 7
     default_formant = 5
     formant_function = generate_variable_formants_point_function(corpus_context, min_formants, max_formants)
     best_prototype_metadata = {}
@@ -90,7 +98,49 @@ def analyze_formant_points_refinement(corpus_context, vowel_label='vowel', durat
             continue
         print (speaker+' '+vowel+': '+str(i+1)+' of '+str(total_speaker_vowel_pairs))
         output = analyze_segments(seg, formant_function, stop_check=stop_check, multiprocessing=multiprocessing)  # Analyze the phone
-
+        
+        if drop_formant:
+            # ADD ALL THE LEAVE-ONE-OUT CANDIDATES
+            for s, data in output.items():
+                new_data = {}
+                for candidate, measurements in data.items():
+                    for leave_out in range(1,1+min(3,candidate)):
+                        new_measurements = {}
+                        new_measurements['Ax'] = measurements['A'+str(leave_out)]
+                        candidate_name = str(candidate)+'x'+str(leave_out)
+                        # print (measurements)
+                        try:
+                            ref_norm_amp = (measurements['A1']/math.log2(measurements['F1']) +
+                                            measurements['A2']/math.log2(measurements['F2']) +
+                                            measurements['A3']/math.log2(measurements['F3']) +
+                                            measurements['A4']/math.log2(measurements['F4'])) / 4
+                        except:
+                            try:
+                                ref_norm_amp = (measurements['A1']/math.log2(measurements['F1']) +
+                                                measurements['A2']/math.log2(measurements['F2']) +
+                                                measurements['A3']/math.log2(measurements['F3'])) / 3
+                            except:
+                                ref_norm_amp = (measurements['A1']/math.log2(measurements['F1']) +
+                                                measurements['A2']/math.log2(measurements['F2'])) / 2
+                        try:
+                            Ax_norm_amp = measurements['A'+str(leave_out)]/math.log2(measurements['F'+str(leave_out)])
+                        except:
+                            Ax_norm_amp = 0
+                        # print (ref_norm_amp, Ax_norm_amp, weak_Ax)
+                        if Ax_norm_amp < ref_norm_amp:
+                            # print('keeping', candidate_name)
+                            for parameter in measurements.keys():
+                                if int(parameter[-1]) < leave_out:
+                                    new_measurements[parameter] = measurements[parameter]
+                                elif int(parameter[-1]) > leave_out:
+                                    new_measurements[parameter[0]+str(int(parameter[-1])-1)] = measurements[parameter]
+                            new_data[candidate_name] = new_measurements
+                        # else:
+                        #     print('excluding', candidate_name)
+                    data[candidate]['Ax'] = data[candidate]['A4']
+                output[s] = {**data, **new_data}        
+                # print (s)
+                # print (output[s])
         if len(seg) < 6:
             print("Not enough observations of vowel {}, at least 6 are needed, only found {}.".format(vowel, len(seg)))
             for s, data in output.items():
@@ -119,6 +169,7 @@ def analyze_formant_points_refinement(corpus_context, vowel_label='vowel', durat
 
         for _ in my_iterations:
 
+            best_numbers = []
             selected_tracks = {}
             prototype_means = prev_prototype_metadata[vowel][0]
             # Get Mahalanobis distance between every new observation and the sample/means
@@ -138,11 +189,40 @@ def analyze_formant_points_refinement(corpus_context, vowel_label='vowel', durat
                         best_number = number
                 selected_tracks[s] = {k: best_track[i] for i, k in enumerate(columns)}
                 best_data[s] = {k: best_track[i] for i, k in enumerate(columns)}
-                best_data[s]['num_formants'] = best_number
+                # print ('best number is',best_number)
+                for extra_column in extra_columns:
+                    best_data[s][extra_column] = output[s][best_number][extra_column]  
+
+                best_data[s]['num_formants'] = float(str(best_number).split('x')[0])
+                # best_data[s]['Fx'] = str(best_number)
+                best_data[s]['Fx'] = int(str(best_number)[0])
+                if 'x' in str(best_number):
+                    best_data[s]['drop_formant'] = int(str(best_number).split('x')[-1])
+                else:
+                    best_data[s]['drop_formant'] = 0
+
+                best_numbers.append(best_number)
+
             if len(seg) >= 6:
                 prototype_metadata = get_mean_SD(selected_tracks)
                 prev_prototype_metadata = prototype_metadata
                 best_prototype_metadata.update(prototype_metadata)
+
+            if _ > 0:
+                changed_numbers = 0
+                for i,bn in enumerate(best_numbers):
+                    if bn != last_iteration_best_numbers[i]:
+                        changed_numbers += 1
+                # print (_, ':', changed_numbers, 'changed out of', len(output))  
+                if changed_numbers == 0:
+                    break      
+            last_iteration_best_numbers = best_numbers
+        log_output.append(','.join([speaker,vowel,str(len(output)),str(_+1)]))
+        # print (speaker+' '+vowel+': '+str(i+1)+' of '+str(total_speaker_vowel_pairs))
+
+    with open('iterations_log.csv', 'w') as f:
+        for i in log_output:
+            f.write(i+'\n')
 
     save_formant_point_data(corpus_context, best_data, num_formants=True)
     corpus_context.cache_hierarchy()


### PR DESCRIPTION
This version of the formant measurement algorithm can skip formants that are measured by Praat, subject to an amplitude criterion. It outputs formant amplitude information, and it tries both even and odd numbers of LPC coefficients (= whole and half formants in Praat). It iterates on each speaker/phone until no further changes are made, to a maximum of 20.