### PR TITLE
Update Neo4j version to 5.x

### DIFF
--- a/bin/pgdb
+++ b/bin/pgdb
@@ -52,7 +52,7 @@ CONFIG = load_config()
 
 TEMP_DIR = os.path.join(CONFIG_DIR, 'downloads')
 
-NEO4J_VERSION = '4.3.3'
+NEO4J_VERSION = '5.17.0'
 
 INFLUXDB_VERSION = '1.8.9'
 


### PR DESCRIPTION
Updating the Neo4j version installed during setup to avoid log4j vulnerability in the currently-downloaded version (4.2-4.4).
Information available at https://community.neo4j.com/t/importerror-cannot-import-name-graphdatabase-from-neo4j/17579