### PR TITLE
Update LaBB-CAT parser

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@main
       - name: Set up Python 3.8

--- a/polyglotdb/io/parsers/labbcat.py
+++ b/polyglotdb/io/parsers/labbcat.py
@@ -51,17 +51,17 @@ class LabbCatParser(AlignerParser):
         try:
             tg = textgrid.openTextgrid(path, includeEmptyIntervals=True)
             new_tiers = []
-            dup_tiers_maxes = {k:0 for k,v in Counter([t.name for t in tg.tiers]).items() if v > 1}
+            dup_tiers_maxes = {k:0 for k,v in Counter([t for t in tg.tierNameList]).items() if v > 1}
             dup_tiers_inds = {k:0 for k in dup_tiers_maxes.keys()}
 
-            for i, t in enumerate(tg.tiers):
-                if t.name in dup_tiers_maxes:
-                    if len(t) > dup_tiers_maxes[t.name]:
+            for i, t in enumerate(tg.tierNameList):
+                if t in dup_tiers_maxes:
+                    if len(t) > dup_tiers_maxes[t]:
                         dup_tiers_maxes[t.name] = len(t)
                         dup_tiers_inds[t.name] = i
-            for i, t in enumerate(tg.tiers):
-                if t.name in dup_tiers_maxes:
-                    if i != dup_tiers_inds[t.name]:
+            for i, t in enumerate(tg.tierNameList):
+                if t in dup_tiers_maxes:
+                    if i != dup_tiers_inds[t]:
                         continue
                 new_tiers.append(t)
             tg.tiers = new_tiers

--- a/polyglotdb/io/parsers/labbcat.py
+++ b/polyglotdb/io/parsers/labbcat.py
@@ -57,8 +57,8 @@ class LabbCatParser(AlignerParser):
             for i, t in enumerate(tg.tierNameList):
                 if t in dup_tiers_maxes:
                     if len(t) > dup_tiers_maxes[t]:
-                        dup_tiers_maxes[t.name] = len(t)
-                        dup_tiers_inds[t.name] = i
+                        dup_tiers_maxes[t] = len(t)
+                        dup_tiers_inds[t] = i
             for i, t in enumerate(tg.tierNameList):
                 if t in dup_tiers_maxes:
                     if i != dup_tiers_inds[t]:


### PR DESCRIPTION
Updates the parsing of LaBB-CAT TextGrids to work with `praatio~=5.0` (think this might have been missed in the version update).

Tested with a LaBB-CAT-aligned corpus with `praatio==5.0`:
```
conda list praatio
# Name                    Version                   Build  Channel
praatio                   5.0.0                    pypi_0    pypi
```

in:
```
with CorpusContext(config) as c:
    try:
        c.load(pg_parser, corpus)
    except ParseError as e:
        pass

    q = c.query_graph(c.word).filter(c.word.label.in_(['are', 'is','am']))
    results = q.all()
    for r in results:
        print(r.label, r.begin)
```
out:
```
loading /home/test with <polyglotdb.io.parsers.labbcat.LabbCatParser object at 0x7f0404bea320>

is 131.613
is 79.85783
is 31.728
```