### PR TITLE
Update runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@main
       - name: Set up Python 3.8


### PR DESCRIPTION
`ubuntu-18.04` runners are deprecated and so blocks the test actions from being triggered. Updates to currently-supported `ubuntu-20.04`. 