### PR TITLE
Clean up dependencies that are no longer used

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
     - librosa
     - scipy
     - praatio
-    - textgrid
     - influxdb
     - tqdm
     - future

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ neo4j
 librosa
 scipy
 praatio
-textgrid
 influxdb
 tqdm
 conch_sounds

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -2,4 +2,3 @@ sphinx
 numpydoc
 mock
 sphinx_rtd_theme
-polyglotdb

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ packages = find:
 install_requires = 
     neo4j
     praatio
-    textgrid
     conch_sounds
     librosa
     influxdb


### PR DESCRIPTION
The textgrid parsing is fully using praatio, so textgrid isn't needed as a dependency anymore.