### PR TITLE
Ensure that only one utterance contained_by relationship is created

### DIFF
--- a/polyglotdb/corpus/pause.py
+++ b/polyglotdb/corpus/pause.py
@@ -1,4 +1,5 @@
 from polyglotdb.corpus.importable import ImportContext
+from polyglotdb.exceptions import SubsetError
 
 
 class PauseContext(ImportContext):
@@ -51,7 +52,9 @@ class PauseContext(ImportContext):
                 else:
                     raise NotImplementedError
                 q.set_pause()
-
+        total_pauses = self.query_graph(self.pause).count()
+        if total_pauses == 0:
+            raise SubsetError(f"No words matched {pause_words} for creating pauses")
         if call_back is not None:
             call_back("Finishing up...")
         for s in self.speakers:

--- a/polyglotdb/io/importer/from_csv.py
+++ b/polyglotdb/io/importer/from_csv.py
@@ -862,7 +862,7 @@ def import_utterance_csv(corpus_context, call_back=None, stop_check=None):
                     path = shortestPath((begin)-[:precedes*0..]->(end))
                 WITH utt, nodes(path) AS words
                 UNWIND words AS w
-                CREATE (w)-[:contained_by]->(utt)
+                MERGE (w)-[:contained_by]->(utt)
             }} IN TRANSACTIONS OF 1000 ROWS
             """
             statement = word_statement.format(
@@ -877,7 +877,7 @@ def import_utterance_csv(corpus_context, call_back=None, stop_check=None):
                 MATCH (n)-[:contained_by*]->()-[:contained_by]->(utt:utterance:{corpus}:speech {{id: csvLine.id}})
                 WITH utt, collect(n) AS subunits
                 UNWIND subunits AS w
-                CREATE (w)-[:contained_by]->(utt)
+                MERGE (w)-[:contained_by]->(utt)
             }} IN TRANSACTIONS OF 1000 ROWS
             """
             statement = word_statement.format(

--- a/tests/test_io_partitur.py
+++ b/tests/test_io_partitur.py
@@ -1,10 +1,8 @@
-import os
-
 import pytest
 
 from polyglotdb import CorpusContext
+from polyglotdb.exceptions import SubsetError
 from polyglotdb.io.inspect.partitur import inspect_partitur
-from polyglotdb.io.parsers.partitur import PartiturParser
 
 
 def test_load_partitur(partitur_test_dir, graph_db):
@@ -20,7 +18,8 @@ def test_load_partitur(partitur_test_dir, graph_db):
         results = q.all()
         assert len(results) == 1
 
-        c.encode_pauses("<p:>")
+        with pytest.raises(SubsetError):
+            c.encode_pauses("<p:>")
 
         c.encode_utterances(min_pause_length=0)
 


### PR DESCRIPTION
Fixes bug where lines in export could be duplicated if utterances were encoded after syllables.